### PR TITLE
update addcomponents.py to make it work with latest db and bugspad.go

### DIFF
--- a/scripts/addcomponents.py
+++ b/scripts/addcomponents.py
@@ -7,5 +7,5 @@ f.close()
 
 url = "http://127.0.0.1:9998/component/"
 for comp in comps:
-    d = {'user': 'kushaldas@gmail.com', "password": 'asdf', 'name':comp['name'], 'description': comp['description'], "product_id": 1, "owner_id": 1}
+    d = {'user': 'kushaldas@gmail.com', "password": 'asdf', 'name':comp['name'], 'description': comp['description'], "product_id": 2, "owner": "kushaldas@gmail.com"}
     r = requests.post(url, data=json.dumps(d))


### PR DESCRIPTION
addcomponents wasn't working anymore, these changes adapt it to new database version (product_id starts at 2), and bugspad.go version: components expects "owner" instead of "owner_id", and it expects a string with the email. (consider getting the owner from 'user', like in the other functions?)
