### PR TITLE
Adds missing AUTH_ERROR response in releases function

### DIFF
--- a/bugspad.go
+++ b/bugspad.go
@@ -346,6 +346,8 @@ func releases(w http.ResponseWriter, r *http.Request) {
 			add_release(release_name)
 			add_redis_release(release_name)
 			fmt.Fprintln(w, SUCCESS)
+		} else {
+			fmt.Fprintln(w, AUTH_ERROR)
 		}
 		return
 	} else if r.Method == "GET" {


### PR DESCRIPTION
Releases function doesn't return AUTH_ERROR string if authentication fails. Adding it just like in the other functions. 
